### PR TITLE
Fix firewall script heredoc quoting

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -978,7 +978,7 @@ RUN bash -c "source $NVM_DIR/nvm.sh && \
     nvm use default && \
     npm install -g @anthropic-ai/claude-code"
 
-RUN cat > ~/init-firewall.sh << EOF
+RUN cat > ~/init-firewall.sh <<'EOF'
 #!/bin/bash
 set -euo pipefail
 if [ "\${DISABLE_FIREWALL:-false}" = "true" ]; then


### PR DESCRIPTION
## Summary
- quote the firewall script heredoc when generating the Dockerfile

## Testing
- `bash -n claudebox`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850b3dcb6b0832199ca15fc2a301b1c

## Summary by Sourcery

Bug Fixes:
- Quote the firewall script heredoc in the Dockerfile generation to preserve script content