### PR TITLE
Fix unbound USERNAME var in firewall script

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -385,6 +385,8 @@ create_build_files() {
     cat > "$build_context/init-firewall.sh" << 'EOF'
 #!/bin/bash
 set -euo pipefail
+# Ensure USERNAME is set to avoid errors when running with -u
+USERNAME=${USERNAME:-$(id -un 2>/dev/null || echo claude)}
 if [ "${DISABLE_FIREWALL:-false}" = "true" ]; then
     echo "Firewall disabled, skipping setup"
     rm -f "$0"


### PR DESCRIPTION
## Summary
- avoid unbound variable error by defaulting `USERNAME` in `init-firewall.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850bb97e12c8321a8240e2baf1c6bca