### PR TITLE
Fix flag handling in claudebox script

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -563,6 +563,28 @@ run_docker_build() {
 main() {
     update_symlink
 
+    # Extract and remove global ClaudeBox flags
+    local _box_flags=()
+    local _args=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -v|--verbose)
+                # already processed
+                shift
+                ;;
+            --dangerously-enable-sudo|--dangerously-disable-firewall|--dangerously-skip-permissions)
+                _box_flags+=("$1")
+                shift
+                ;;
+            *)
+                _args+=("$1")
+                shift
+                ;;
+        esac
+    done
+    BOX_FLAGS=("${DEFAULT_FLAGS[@]}" "${_box_flags[@]}")
+    set -- "${_args[@]}"
+
     # Check Docker
     local docker_status
     docker_status=$(check_docker; echo $?)
@@ -701,7 +723,7 @@ main() {
                 "
             else
                 docker exec -it -u "$DOCKER_USER" "$temp_container" \
-                    /home/$DOCKER_USER/claude-wrapper "${DEFAULT_FLAGS[@]}" "$cmd" "$@"
+                    /home/$DOCKER_USER/claude-wrapper "${BOX_FLAGS[@]}" "$cmd" "$@"
             fi
 
             # Commit changes back to image
@@ -1430,7 +1452,7 @@ EOF
        "${extra_mounts[@]}" \
        --cap-add NET_ADMIN \
        --cap-add NET_RAW \
-       "$IMAGE_NAME" "${DEFAULT_FLAGS[@]}" "${RUN_ARGS[@]:-$@}"
+       "$IMAGE_NAME" "${BOX_FLAGS[@]}" "$@"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- parse and strip security flags before passing args to Claude
- keep default flags enabled for update/config commands
- include default and parsed flags when launching Docker

## Testing
- `shellcheck claudebox`
- `bash -n claudebox`


------
https://chatgpt.com/codex/tasks/task_e_68521a6ba6148321a7881ab0d9cc070f

## Summary by Sourcery

Fix how the claudebox script processes command-line flags by parsing and stripping security options, preserving defaults for specific commands, and passing the resulting flags when launching the Docker container.

Bug Fixes:
- Parse and strip security flags before forwarding arguments to Claude

Enhancements:
- Preserve default flags for update and config commands
- Include both default and user-provided flags when starting the Docker container

Tests:
- Add shellcheck and Bash syntax validation for the claudebox script