### PR TITLE
Fix chown failure if local group ID exists

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -1261,7 +1261,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y -qq curl gnupg ca-certificates sudo git iptables ipset && \
     apt-get clean
 
-RUN groupadd -g $GROUP_ID $USERNAME || true && \
+RUN groupadd -o -g $GROUP_ID $USERNAME && \
     useradd -m -u $USER_ID -g $GROUP_ID -s /bin/bash $USERNAME
 
 # Persist bash history


### PR DESCRIPTION
If the user's group ID on the host happens to be an ID that's already
present in the Debian base image's `/etc/group` file, the `groupadd`
command doesn't add a new `claudebox` group. ClaudeBox ignores that
command's failure, but the lack of the group causes a failure when
the startup script tries to run `chown claudebox:claudebox`.

Fix it by adding the `-o` option to `groupadd`, which enables adding
groups with duplicate IDs. Duplicate group IDs aren't good practice
in general, but in the context of ClaudeBox, shouldn't cause any
problems.
