### PR TITLE
Fix failure when run with no arguments

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -662,7 +662,7 @@ fi
 
 cd /home/DOCKERUSER
 # Check if we're in shell mode
-if [[ "$1" == "--shell-mode" ]]; then
+if [[ "${1:-}" == "--shell-mode" ]]; then
     shift  # Remove --shell-mode flag
     exec su DOCKERUSER -c "source /home/DOCKERUSER/.nvm/nvm.sh && cd /workspace && exec /bin/zsh"
 else


### PR DESCRIPTION
Running `claudebox` with no arguments was failing with an unbound
variable error because the start script was trying to test the value
of the first command-line argument.
