### PR TITLE
Add host detection and refine nala use

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -9,6 +9,34 @@ readonly USER_ID=$(id -u)
 readonly GROUP_ID=$(id -g)
 readonly PROJECT_DIR="$(pwd)"
 
+# ────────────────────────────────────────────────────────────────────────────────
+#  Cross‑platform host detection (Linux vs. macOS) and FS case‑sensitivity check
+# ────────────────────────────────────────────────────────────────────────────────
+OS_TYPE="$(uname -s)"
+case "$OS_TYPE" in
+  Darwin*) HOST_OS="macOS" ;;
+  Linux*)  HOST_OS="linux" ;;
+  *) echo "Unsupported operating system: $OS_TYPE" >&2; exit 1 ;;
+esac
+
+# Detect case‑insensitive default macOS filesystems (HFS+/APFS)
+# Exit code 0  → case‑sensitive, 1 → case‑insensitive
+is_case_sensitive_fs() {
+  local t1 t2
+  t1="$(mktemp "/tmp/.fs_case_test.XXXXXXXX")"
+  t2="${t1^^}"          # same name, different case
+  touch "$t1"
+  [[ -e "$t2" && "$t1" != "$t2" ]] && { rm -f "$t1"; return 1; }
+  rm -f "$t1"
+  return 0
+}
+
+# Normalise docker‑build contexts on case‑insensitive hosts to avoid collisions
+if [[ "$HOST_OS" == "macOS" ]] && ! is_case_sensitive_fs; then
+  export COMPOSE_DOCKER_CLI_BUILD=1   # new BuildKit path‑normaliser
+  export DOCKER_BUILDKIT=1
+fi
+
 # Cross-platform script path resolution
 get_script_path() {
     local source="${BASH_SOURCE[0]:-$0}"
@@ -1231,7 +1259,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 	curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg]" \
-    "https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && nala update && \
+    "https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && nala --assume-yes update && \
 	nala install -y --no-autoremove --no-install-recommends apt-utils wget zsh fzf gnupg ca-certificates sudo git iptables ipset gh unzip jq \
 	sudo procps vim nano less ca-certificates && \
 	rm -rf /var/lib/apt/lists/*
@@ -1328,9 +1356,9 @@ DOCKERFILE
         cat >> "$dockerfile" <<DOCKERFILE
 # ${PROFILE_DESCRIPTIONS[$profile]}
 RUN export DEBIAN_FRONTEND=noninteractive && \\
-	apt-get update -qq && \\
-	nala install -y --no-autoremove ${pkg_list[*]} && \\
-	nala clean && rm -rf /var/lib/apt/lists/*
+        nala --assume-yes update && \\
+        nala install -y --no-autoremove ${pkg_list[*]} && \\
+        nala clean && rm -rf /var/lib/apt/lists/*
 DOCKERFILE
 				case "$profile" in
 					rust)


### PR DESCRIPTION
## Summary
- detect host OS and adjust Docker BuildKit on macOS
- ensure `nala update` uses `--assume-yes` flag

## Testing
- `bash -n claudebox`


------
https://chatgpt.com/codex/tasks/task_e_6858bb016e18832189bb747bf7fe3385

## Summary by Sourcery

Add host OS detection to configure Docker BuildKit on macOS, ensure non-interactive package updates with nala, and include syntax validation for the claudebox script.

Bug Fixes:
- Ensure `nala update` runs with --assume-yes to avoid interactive prompts

Enhancements:
- Detect the host OS and enable Docker BuildKit explicitly on macOS

Tests:
- Add shell syntax validation for the claudebox script