### PR TITLE
Fix profile validation for empty entries

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -791,7 +791,9 @@ main() {
 
             local selected=() remaining=()
             while [[ $# -gt 0 ]]; do
-                if [[ -n "${PROFILES[$1]:-}" ]]; then
+                # accept profiles even if the value is empty
+                # check that the key exists in the PROFILES associative array
+                if [[ -v PROFILES[$1] ]]; then
                     selected+=("$1")
                     shift
                 else


### PR DESCRIPTION
## Summary
- allow empty profile values by checking key existence in the PROFILES array

## Testing
- `bash -n claudebox`


------
https://chatgpt.com/codex/tasks/task_e_685b9cafe9fc83218cbe862bce6a095b

## Summary by Sourcery

Bug Fixes:
- Allow empty profile values by validating key presence in PROFILES instead of value content.