### PR TITLE
Fix warning if bash < v4 try to find brew macOS version

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Only re-exec with newer bash if current version is too old
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    echo "Current Bash version is too old (${BASH_VERSION})."
+    # Try to find Homebrew-installed bash
+    BREW_BASH="$(brew --prefix bash 2>/dev/null || true)/bin/bash"
+    
+    if [[ -x "$BREW_BASH" && "$BASH" != "$BREW_BASH" ]]; then
+        echo "Switching to newer Bash: $BREW_BASH"
+        exec "$BREW_BASH" "$0" "$@"
+    else
+        echo "Newer Bash not found, for macOS install with $ brew install bash."
+        sleep 5
+    fi
+fi
+
 # Configuration
 DEFAULT_FLAGS=()
 # readonly IMAGE_NAME="claudebox"  # Now computed per project


### PR DESCRIPTION
Add check for older bash version <4, 
and then try to locate macOS brew installed bash v4, if not sleep 5 sec and continue.

e.g. output with no brew bash 4.
```
./claudebox 
Current Bash version is too old (3.2.57(1)-release).
Newer Bash not found, for macOS install with $ brew install bash.
./claudebox: line 1337: syntax error near unexpected token `;'
```

then install newer bash
`brew install bash`

```
./claudebox      
Current Bash version is too old (3.2.57(1)-release).
Switching to newer Bash: /opt/homebrew/opt/bash/bin/bash
Untagged: claudebox-users_diepes_github_claudebox_7d3c55:latest
Deleted: sha256:d43634c225b903bd898868e1217eab0c0953925a843ce02c7203cd3aca5615b4
...
...
```

## Summary by Sourcery

Add runtime check for Bash versions earlier than 4 on macOS, automatically switch to a Homebrew-installed Bash if available, or prompt the user to install it and pause before continuing.

Enhancements:
- Detect Bash version at startup and flag versions <4
- Search common Homebrew install paths for Bash v4 on macOS
- Re-execute the script under the newer Bash interpreter when found
- Prompt the user to install Bash via brew and pause briefly if no newer Bash is located