### PR TITLE
Fix  user USER_ID and GROUP_ID in container rather than USERNAME

### DIFF
--- a/claudebox
+++ b/claudebox
@@ -2158,7 +2158,7 @@ DOCKERFILE
 
 # Copy init-firewall script
 COPY --chmod=755 init-firewall /home/$USERNAME/init-firewall
-RUN chown $USERNAME:$USERNAME /home/$USERNAME/init-firewall
+RUN chown $USER_ID:$GROUP_ID /home/$USERNAME/init-firewall
 
 USER $USERNAME
 RUN bash -c "source $NVM_DIR/nvm.sh && claude --version"


### PR DESCRIPTION

On MacOS the GROUP_ID we get with 
https://github.com/RchGrav/claudebox/blob/82302e37d5e0ff72ca15f0ae9c8450d6f47e11be/claudebox#L24

Can conflict with existing group in container.
This does not cause a error as the creation of the group is optional and just continues if group exists
https://github.com/RchGrav/claudebox/blob/82302e37d5e0ff72ca15f0ae9c8450d6f47e11be/claudebox#L1963

This then fails when we assume the USERNAME is the same as the GROUPNAME
https://github.com/RchGrav/claudebox/blob/82302e37d5e0ff72ca15f0ae9c8450d6f47e11be/claudebox#L2161

Fix is to just use the USER_ID and GROUP_ID in the chown.

