### PR TITLE
fix: Sanize & before substitution

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -585,7 +585,9 @@ LABEL claudebox.project=\"$project_folder_name\""
     
     # Replace placeholders in the project template
     local final_dockerfile="$base_dockerfile"
-    final_dockerfile="${final_dockerfile//\{\{PROFILE_INSTALLATIONS\}\}/$profile_installations}"
+    sanitized_pi="${profile_installations//\\/\\\\}"
+    sanitized_pi="${sanitized_pi//&/\\&}"
+    final_dockerfile="${final_dockerfile//\{\{PROFILE_INSTALLATIONS\}\}/$sanitized_pi}"
     final_dockerfile="${final_dockerfile//\{\{LABELS\}\}/$labels}"
     
     echo "$final_dockerfile" > "$dockerfile"


### PR DESCRIPTION
Adding any profile with a literal `&&`, I run into an error:

```
> claudebox add php
> claudebox
....
 => ERROR [2/5] RUN apt-get update {{PROFILE_INSTALLATIONS}}{{PROFILE_INSTALLATIONS}} apt-get install -y php php-cli php-fpm php-mysql php-pgsql php-  0.2s
------
 > [2/5] RUN apt-get update {{PROFILE_INSTALLATIONS}}{{PROFILE_INSTALLATIONS}} apt-get install -y php php-cli php-fpm php-mysql php-pgsql php-sqlite3 php-curl php-gd php-mbstring php-xml php-zip composer {{PROFILE_INSTALLATIONS}}{{PROFILE_INSTALLATIONS}} apt-get clean:
0.104 E: The update command takes no arguments
------
Dockerfile:8
--------------------
   6 |
   7 |     #
   8 | >>> RUN apt-get update {{PROFILE_INSTALLATIONS}}{{PROFILE_INSTALLATIONS}} apt-get install -y php php-cli php-fpm php-mysql php-pgsql php-sqlite3 php-curl php-gd php-mbstring php-xml php-zip composer {{PROFILE_INSTALLATIONS}}{{PROFILE_INSTALLATIONS}} apt-get clean
   9 |
  10 |     #
--------------------
...
```
This patch fixes that for me.

As a sidenote, it appears packages are not honored a the moment, e.g.:

```
claudbox install htop
```

adds an entry to `profile.ini`, but does not yet install the package to the container.