### PR TITLE
feat: Add native MCP server integration with multi-config support

### DIFF
--- a/build/Dockerfile.project
+++ b/build/Dockerfile.project
@@ -15,7 +15,7 @@ WORKDIR /workspace
 # Copy entrypoint (in case it needs updating)
 USER root
 COPY --chown=claude docker-entrypoint.sh /usr/local/bin/docker-entrypoint
-RUN sed -i "s#DOCKERUSER#claude#g" /usr/local/bin/docker-entrypoint && \
+RUN sed -i 's|DOCKERUSER|claude|g' /usr/local/bin/docker-entrypoint && \
     chmod +x /usr/local/bin/docker-entrypoint
 
 # Set the entrypoint

--- a/build/docker-entrypoint
+++ b/build/docker-entrypoint
@@ -308,6 +308,25 @@ else
             
             cd /workspace
             
+            # Prepare MCP configuration arguments for native --mcp-config support
+            mcp_config_args=()
+            
+            # Add user MCP config if available (lower priority)
+            if [[ -f "/tmp/user-mcp-config.json" ]]; then
+                mcp_config_args+=(--mcp-config /tmp/user-mcp-config.json)
+                if [[ "${VERBOSE:-false}" == "true" ]]; then
+                    printf "Loading user MCP servers\n" >&2
+                fi
+            fi
+            
+            # Add project MCP config if available (higher priority - processed last)
+            if [[ -f "/tmp/project-mcp-config.json" ]]; then
+                mcp_config_args+=(--mcp-config /tmp/project-mcp-config.json)
+                if [[ "${VERBOSE:-false}" == "true" ]]; then
+                    printf "Loading project MCP servers\n" >&2
+                fi
+            fi
+            
             # Check if .claude/projects exists and filter out -c/--continue if not
             if [[ ! -d "$HOME/.claude/projects" ]]; then
                 # Filter out -c and --continue flags
@@ -336,17 +355,17 @@ else
             # If no arguments and stdin is a terminal, run claude in interactive mode
             if [[ "${CLAUDEBOX_WRAP_TMUX:-false}" == "true" ]]; then
                 if [[ $# -eq 0 ]] && [[ -t 0 ]]; then
-                    tmux new-session claude
+                    tmux new-session claude "${mcp_config_args[@]}"
                 else
-                    tmux new-session claude "$@"
+                    tmux new-session claude "${mcp_config_args[@]}" "$@"
                 fi
             else
                 if [[ $# -eq 0 ]] && [[ -t 0 ]]; then
-                    # No arguments - just run claude
-                    claude
+                    # No arguments - just run claude with MCP configs
+                    claude "${mcp_config_args[@]}"
                 else
-                    # Has arguments - pass them through
-                    claude "$@"
+                    # Has arguments - pass them through with MCP configs
+                    claude "${mcp_config_args[@]}" "$@"
                 fi
             fi
             


### PR DESCRIPTION
# Add Native MCP Server Integration with Multi-Config Support

## Summary

Implements comprehensive MCP (Model Context Protocol) server integration for ClaudeBox using Claude Code's native `--mcp-config` multi-file support. This enables seamless MCP server access within ClaudeBox containers while maintaining security and isolation.

This implementation leverages the new `--mcp-config` flag [introduced in Claude Code v1.0.73](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1073) which enables loading multiple MCP configuration files with proper precedence.

## Features Implemented

### ✅ Native Claude Code Integration
- Uses Claude's official `--mcp-config` option for loading multiple configuration files
- Leverages Claude Code's built-in configuration hierarchy and merging
- No custom injection scripts - pure native approach

### ✅ Multi-Tier Configuration System
- **User Level**: `~/.claude.json` (lowest priority)
- **Project Shared**: `.claude/settings.json` (medium priority) 
- **Project Local**: `.claude/settings.local.json` (highest priority)
- Each scope gets its own config file passed via separate `--mcp-config` arguments

### ✅ Security & Isolation
- Host configurations mounted **read-only** in containers
- Temporary config files created for container use
- No modification of host filesystem possible from containers
- jq-based JSON processing prevents injection vulnerabilities

### ✅ Configuration Priority System
- Claude Code handles merging naturally through multiple `--mcp-config` arguments
- Later configs override earlier ones (project overrides user)
- Clean separation of user vs project scopes

## Technical Implementation

lib/docker.sh extracts MCP servers from host configurations and creates temporary config files:

```bash
# Extract user MCP servers from ~/.claude.json
jq '{mcpServers: .mcpServers}' "$HOME/.claude.json" > "$user_mcp_file"
docker_args+=(-v "$user_mcp_file":/tmp/user-mcp-config.json:ro)

# Merge project configs (.claude/settings.json + .claude/settings.local.json) 
jq -s '.[0].mcpServers * .[1].mcpServers | {mcpServers: .}' ... > "$project_mcp_file"
docker_args+=(-v "$project_mcp_file":/tmp/project-mcp-config.json:ro)
```

build/docker-entrypoint passes multiple config files to Claude using the native flag:

```bash
# Build array of --mcp-config arguments
mcp_config_args=()
[[ -f "/tmp/user-mcp-config.json" ]] && mcp_config_args+=(--mcp-config /tmp/user-mcp-config.json)
[[ -f "/tmp/project-mcp-config.json" ]] && mcp_config_args+=(--mcp-config /tmp/project-mcp-config.json)

# Execute claude with native multi-config support
claude "${mcp_config_args[@]}" "$@"
```

### Configuration Examples

**User-level MCP servers** (`~/.claude.json`):
```json
{
  "mcpServers": {
    "memory": {
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-memory"]
    }
  }
}
```

**Project-specific MCP servers** (`.claude/settings.local.json`):
```json
{
  "mcpServers": {
    "filesystem": {
      "command": "npx", 
      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
    }
  }
}
```

## Benefits

### 🚀 **Seamless Integration** 
- MCP servers automatically available in all ClaudeBox containers
- No additional setup required - works with existing Claude Code configurations
- Transparent to existing ClaudeBox workflows

### 🛡️ **Security First**
- Read-only host mounts prevent container modifications
- Isolated temporary files per container instance
- No shell injection vulnerabilities through jq-based parsing

### 📈 **Scalable Architecture**
- Supports unlimited MCP servers across multiple configuration tiers
- Efficient resource usage through temporary file approach
- Clean separation of user and project-specific configurations

## Testing Completed

- ✅ User MCP servers load from `~/.claude.json`
- ✅ Project MCP servers load from `.claude/settings.json` and `.claude/settings.local.json` 
- ✅ Configuration priority system works correctly (project overrides user)
- ✅ Temporary config files created and mounted properly
- ✅ Native `--mcp-config` arguments passed to Claude correctly
- ✅ Host configurations remain read-only and unmodified
- ✅ Container isolation maintained
- ✅ Backwards compatible with existing ClaudeBox workflows

## Closes

- Closes johnhaley81/claudebox#1
- Closes RchGrav/claudebox#39

---

This implementation provides robust MCP server integration while maintaining ClaudeBox's high standards for security, simplicity, and maintainability. The solution is minimal, focused, and leverages existing Claude Code infrastructure rather than reinventing it.