### PR TITLE
feat: Add dynamic profile system for ClaudeBox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           export TEST_HOME=$(mktemp -d)
           export HOME="$TEST_HOME"
           echo "Testing installation in $HOME"
-          bash ./claudebox.run.sh
+          bash ./claudebox.run
           ls -la ~/.claudebox/scripts/bin/
           ~/.local/bin/claudebox --help || echo "OK (help displayed or no version flag)"
 
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: claudebox-installer
-          path: claudebox.run.sh
+          path: claudebox.run
 
   release:
     needs: test-installer
@@ -56,6 +56,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./claudebox.run.sh
-          asset_name: claudebox.run.sh
+          asset_path: ./claudebox.run
+          asset_name: claudebox.run
           asset_content_type: application/x-sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,11 @@ jobs:
           export HOME="$TEST_HOME"
           echo "Testing installation in $HOME"
           bash ./claudebox.run
-          ls -la ~/.claudebox/scripts/bin/
+          # Verify installation created the expected directories
+          test -d ~/.claudebox/source
+          test -f ~/.claudebox/archive.tar.gz
+          test -L ~/.local/bin/claudebox
+          # Test that claudebox command works
           ~/.local/bin/claudebox --help || echo "OK (help displayed or no version flag)"
 
       - name: Upload installer artifact

--- a/lib/commands.profile.sh
+++ b/lib/commands.profile.sh
@@ -163,7 +163,6 @@ _cmd_add() {
                 fi
 
                 local current_packages=()
-                local current_packages=()
                 while IFS= read -r line; do
                     [[ -n "$line" ]] && current_packages+=("$line")
                 done < <(read_profile_section "$profile_file" "packages")
@@ -199,7 +198,6 @@ _cmd_add() {
 
     update_profile_section "$profile_file" "profiles" "${selected[@]}"
 
-    local all_profiles=()
     local all_profiles=()
     while IFS= read -r line; do
         [[ -n "$line" ]] && all_profiles+=("$line")
@@ -379,7 +377,6 @@ _cmd_install() {
 
     update_profile_section "$profile_file" "packages" "$@"
 
-    local all_packages=()
     local all_packages=()
     while IFS= read -r line; do
         [[ -n "$line" ]] && all_packages+=("$line")

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -11,86 +11,148 @@ _read_ini() {               # $1=file $2=section $3=key
 }
 
 
-# -------- Profile functions (Bash 3.2 compatible) -----------------------------
-get_profile_packages() {
-    case "$1" in
-        core) echo "gcc g++ make git pkg-config libssl-dev libffi-dev zlib1g-dev tmux" ;;
-        build-tools) echo "cmake ninja-build autoconf automake libtool" ;;
-        shell) echo "rsync openssh-client man-db gnupg2 aggregate file" ;;
-        networking) echo "iptables ipset iproute2 dnsutils" ;;
-        c) echo "gdb valgrind clang clang-format clang-tidy cppcheck doxygen libboost-all-dev libcmocka-dev libcmocka0 lcov libncurses5-dev libncursesw5-dev" ;;
-        openwrt) echo "rsync libncurses5-dev zlib1g-dev gawk gettext xsltproc libelf-dev ccache subversion swig time qemu-system-arm qemu-system-aarch64 qemu-system-mips qemu-system-x86 qemu-utils" ;;
-        rust) echo "" ;;  # Rust installed via rustup
-        python) echo "" ;;  # Managed via uv
-        go) echo "" ;;  # Installed from tarball
-        javascript) echo "" ;;  # Installed via nvm
-        java) echo "openjdk-17-jdk maven gradle ant" ;;
-        ruby) echo "ruby-full ruby-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common" ;;
-        php) echo "php php-cli php-fpm php-mysql php-pgsql php-sqlite3 php-curl php-gd php-mbstring php-xml php-zip composer" ;;
-        database) echo "postgresql-client mysql-client sqlite3 redis-tools mongodb-clients" ;;
-        devops) echo "docker.io docker-compose kubectl helm terraform ansible awscli" ;;
-        web) echo "nginx apache2-utils httpie" ;;
-        embedded) echo "gcc-arm-none-eabi gdb-multiarch openocd picocom minicom screen" ;;
-        datascience) echo "r-base" ;;
-        security) echo "nmap tcpdump wireshark-common netcat-openbsd john hashcat hydra" ;;
-        ml) echo "" ;;  # Just cmake needed, comes from build-tools now
-        *) echo "" ;;
-    esac
+# -------- Dynamic Profile System (Bash 3.2 compatible) -----------------------
+
+# Get profile directories
+get_profile_dirs() {
+    # System profiles first (lower priority)
+    local dirs=""
+    if [[ -d "$SCRIPT_DIR/tooling/profiles" ]]; then
+        dirs="$SCRIPT_DIR/tooling/profiles"
+    fi
+    # User profiles second (higher priority, can override system)
+    if [[ -d "$HOME/.claudebox/profiles" ]]; then
+        dirs="${dirs:+$dirs }$HOME/.claudebox/profiles"
+    fi
+    printf '%s\n' "$dirs"
 }
 
-get_profile_description() {
-    case "$1" in
-        core) echo "Core Development Utilities (compilers, VCS, shell tools)" ;;
-        build-tools) echo "Build Tools (CMake, autotools, Ninja)" ;;
-        shell) echo "Optional Shell Tools (fzf, SSH, man, rsync, file)" ;;
-        networking) echo "Network Tools (IP stack, DNS, route tools)" ;;
-        c) echo "C/C++ Development (debuggers, analyzers, Boost, ncurses, cmocka)" ;;
-        openwrt) echo "OpenWRT Development (cross toolchain, QEMU, distro tools)" ;;
-        rust) echo "Rust Development (installed via rustup)" ;;
-        python) echo "Python Development (managed via uv)" ;;
-        go) echo "Go Development (installed from upstream archive)" ;;
-        javascript) echo "JavaScript/TypeScript (Node installed via nvm)" ;;
-        java) echo "Java Development (OpenJDK 17, Maven, Gradle, Ant)" ;;
-        ruby) echo "Ruby Development (gems, native deps, XML/YAML)" ;;
-        php) echo "PHP Development (PHP + extensions + Composer)" ;;
-        database) echo "Database Tools (clients for major databases)" ;;
-        devops) echo "DevOps Tools (Docker, Kubernetes, Terraform, etc.)" ;;
-        web) echo "Web Dev Tools (nginx, HTTP test clients)" ;;
-        embedded) echo "Embedded Dev (ARM toolchain, serial debuggers)" ;;
-        datascience) echo "Data Science (Python, Jupyter, R)" ;;
-        security) echo "Security Tools (scanners, crackers, packet tools)" ;;
-        ml) echo "Machine Learning (build layer only; Python via uv)" ;;
-        *) echo "" ;;
-    esac
+# Execute a profile script with a command
+execute_profile() {
+    local profile="$1"
+    local command="$2"
+    
+    # Search for profile script in directories (reverse order for priority)
+    local profile_dirs
+    profile_dirs=$(get_profile_dirs)
+    
+    # Check user profiles first (higher priority)
+    if [[ -d "$HOME/.claudebox/profiles" ]] && [[ -x "$HOME/.claudebox/profiles/${profile}.sh" ]]; then
+        "$HOME/.claudebox/profiles/${profile}.sh" "$command"
+        return $?
+    fi
+    
+    # Then check system profiles
+    if [[ -d "$SCRIPT_DIR/tooling/profiles" ]] && [[ -x "$SCRIPT_DIR/tooling/profiles/${profile}.sh" ]]; then
+        "$SCRIPT_DIR/tooling/profiles/${profile}.sh" "$command"
+        return $?
+    fi
+    
+    return 1
 }
 
+# Get all available profile names
 get_all_profile_names() {
-    echo "core build-tools shell networking c openwrt rust python go javascript java ruby php database devops web embedded datascience security ml"
+    local profiles=()
+    local profile_dirs
+    profile_dirs=$(get_profile_dirs)
+    
+    for dir in $profile_dirs; do
+        if [[ -d "$dir" ]]; then
+            for script in "$dir"/*.sh; do
+                if [[ -f "$script" ]] && [[ -x "$script" ]]; then
+                    local name
+                    name=$(basename "$script" .sh)
+                    # Add if not already in list
+                    local found=false
+                    for p in "${profiles[@]}"; do
+                        if [[ "$p" == "$name" ]]; then
+                            found=true
+                            break
+                        fi
+                    done
+                    if [[ "$found" == "false" ]]; then
+                        profiles+=("$name")
+                    fi
+                fi
+            done
+        fi
+    done
+    
+    printf '%s ' "${profiles[@]}"
 }
 
+# Check if a profile exists
 profile_exists() {
     local profile="$1"
-    for p in $(get_all_profile_names); do
-        [[ "$p" == "$profile" ]] && return 0
+    local profile_dirs
+    profile_dirs=$(get_profile_dirs)
+    
+    for dir in $profile_dirs; do
+        if [[ -f "$dir/${profile}.sh" ]] && [[ -x "$dir/${profile}.sh" ]]; then
+            return 0
+        fi
     done
     return 1
 }
 
+# Get profile description
+get_profile_description() {
+    local profile="$1"
+    local info
+    info=$(execute_profile "$profile" "info" 2>/dev/null)
+    if [[ $? -eq 0 ]] && [[ -n "$info" ]]; then
+        # Extract description part after the |
+        printf '%s\n' "$info" | cut -d'|' -f2
+    else
+        printf '\n'
+    fi
+}
+
+# Get profile packages
+get_profile_packages() {
+    local profile="$1"
+    execute_profile "$profile" "packages" 2>/dev/null || printf '\n'
+}
+
+# Get profile Dockerfile content
+get_profile_dockerfile() {
+    local profile="$1"
+    execute_profile "$profile" "dockerfile" 2>/dev/null || printf '\n'
+}
+
+# Expand profile with its dependencies
 expand_profile() {
-    case "$1" in
-        c) echo "core build-tools c" ;;
-        openwrt) echo "core build-tools openwrt" ;;
-        ml) echo "core build-tools ml" ;;
-        rust|go|python|php|ruby|java|database|devops|web|embedded|datascience|security|javascript)
-            echo "core $1"
-            ;;
-        shell|networking|build-tools|core)
-            echo "$1"
-            ;;
-        *)
-            echo "$1"
-            ;;
-    esac
+    local profile="$1"
+    local expanded=()
+    local visited=()
+    
+    # Recursive function to expand dependencies
+    expand_deps() {
+        local p="$1"
+        # Check if already visited
+        for v in "${visited[@]}"; do
+            [[ "$v" == "$p" ]] && return
+        done
+        visited+=("$p")
+        
+        # Get dependencies
+        local deps
+        deps=$(execute_profile "$p" "depends" 2>/dev/null || echo "")
+        
+        # Process dependencies first (depth-first)
+        for dep in $deps; do
+            if profile_exists "$dep"; then
+                expand_deps "$dep"
+            fi
+        done
+        
+        # Add this profile
+        expanded+=("$p")
+    }
+    
+    expand_deps "$profile"
+    printf '%s ' "${expanded[@]}"
 }
 
 # -------- Profile file management ---------------------------------------------
@@ -188,157 +250,34 @@ get_current_profiles() {
 }
 
 # -------- Profile installation functions for Docker builds -------------------
-get_profile_core() {
-    local packages=$(get_profile_packages "core")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
+# Legacy compatibility function - maps old function calls to new system
+# This can be removed once main.sh is updated
+get_profile_core() { get_profile_dockerfile "core"; }
+get_profile_build_tools() { get_profile_dockerfile "build-tools"; }
+get_profile_shell() { get_profile_dockerfile "shell"; }
+get_profile_networking() { get_profile_dockerfile "networking"; }
+get_profile_c() { get_profile_dockerfile "c"; }
+get_profile_openwrt() { get_profile_dockerfile "openwrt"; }
+get_profile_rust() { get_profile_dockerfile "rust"; }
+get_profile_python() { get_profile_dockerfile "python"; }
+get_profile_go() { get_profile_dockerfile "go"; }
+get_profile_javascript() { get_profile_dockerfile "javascript"; }
+get_profile_java() { get_profile_dockerfile "java"; }
+get_profile_ruby() { get_profile_dockerfile "ruby"; }
+get_profile_php() { get_profile_dockerfile "php"; }
+get_profile_database() { get_profile_dockerfile "database"; }
+get_profile_devops() { get_profile_dockerfile "devops"; }
+get_profile_web() { get_profile_dockerfile "web"; }
+get_profile_embedded() { get_profile_dockerfile "embedded"; }
+get_profile_datascience() { get_profile_dockerfile "datascience"; }
+get_profile_security() { get_profile_dockerfile "security"; }
+get_profile_ml() { get_profile_dockerfile "ml"; }
 
-get_profile_build_tools() {
-    local packages=$(get_profile_packages "build-tools")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_shell() {
-    local packages=$(get_profile_packages "shell")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_networking() {
-    local packages=$(get_profile_packages "networking")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_c() {
-    local packages=$(get_profile_packages "c")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_openwrt() {
-    local packages=$(get_profile_packages "openwrt")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_rust() {
-    cat << 'EOF'
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/home/claude/.cargo/bin:$PATH"
-EOF
-}
-
-get_profile_python() {
-    cat << 'EOF'
-# Python profile - uv already installed in base image
-# Python venv and dev tools are managed via entrypoint flag system
-EOF
-}
-
-get_profile_go() {
-    cat << 'EOF'
-RUN wget -O go.tar.gz https://golang.org/dl/go1.21.0.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
-ENV PATH="/usr/local/go/bin:$PATH"
-EOF
-}
-
-get_profile_javascript() {
-    cat << 'EOF'
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-ENV NVM_DIR="/home/claude/.nvm"
-RUN . $NVM_DIR/nvm.sh && nvm install --lts
-USER claude
-RUN bash -c "source $NVM_DIR/nvm.sh && npm install -g typescript eslint prettier yarn pnpm"
-USER root
-EOF
-}
-
-get_profile_java() {
-    local packages=$(get_profile_packages "java")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_ruby() {
-    local packages=$(get_profile_packages "ruby")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_php() {
-    local packages=$(get_profile_packages "php")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_database() {
-    local packages=$(get_profile_packages "database")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_devops() {
-    local packages=$(get_profile_packages "devops")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_web() {
-    local packages=$(get_profile_packages "web")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_embedded() {
-    local packages=$(get_profile_packages "embedded")
-    if [[ -n "$packages" ]]; then
-        cat << 'EOF'
-RUN apt-get update && apt-get install -y gcc-arm-none-eabi gdb-multiarch openocd picocom minicom screen && apt-get clean
-USER claude
-RUN ~/.local/bin/uv tool install platformio
-USER root
-EOF
-    fi
-}
-
-get_profile_datascience() {
-    local packages=$(get_profile_packages "datascience")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_security() {
-    local packages=$(get_profile_packages "security")
-    if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
-    fi
-}
-
-get_profile_ml() {
-    # ML profile just needs build tools which are dependencies
-    echo "# ML profile uses build-tools for compilation"
-}
-
-export -f _read_ini get_profile_packages get_profile_description get_all_profile_names profile_exists expand_profile
+# Export dynamic profile functions
+export -f _read_ini get_profile_dirs execute_profile get_all_profile_names profile_exists
+export -f get_profile_description get_profile_packages get_profile_dockerfile expand_profile
 export -f get_profile_file_path read_config_value read_profile_section update_profile_section get_current_profiles
+# Export legacy compatibility functions (can be removed after main.sh update)
 export -f get_profile_core get_profile_build_tools get_profile_shell get_profile_networking get_profile_c get_profile_openwrt
 export -f get_profile_rust get_profile_python get_profile_go get_profile_javascript get_profile_java get_profile_ruby
 export -f get_profile_php get_profile_database get_profile_devops get_profile_web get_profile_embedded get_profile_datascience

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -200,7 +200,9 @@ update_profile_section() {
     local new_items=("$@")
 
     local existing_items=()
-    readarray -t existing_items < <(read_profile_section "$profile_file" "$section")
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && existing_items+=("$line")
+    done < <(read_profile_section "$profile_file" "$section")
 
     local all_items=()
     for item in "${existing_items[@]}"; do

--- a/main.sh
+++ b/main.sh
@@ -600,7 +600,7 @@ LABEL claudebox.project=\"$project_folder_name\""
     ' <<<"$base_dockerfile") || error "Failed to apply Dockerfile substitutions"
 
     # Guard: ensure no unreplaced placeholders remain
-    if grep -q '{{PROFILE_INSTALLATIONS}}' <<<"$final_dockerfile" grep -q '{{LABELS}}' <<<"$final_dockerfile"; then
+    if grep -q '{{PROFILE_INSTALLATIONS}}' <<<"$final_dockerfile" || grep -q '{{LABELS}}' <<<"$final_dockerfile"; then
     error "Unreplaced placeholders remain in generated Dockerfile"
     fi
 

--- a/templates/profile.template.sh
+++ b/templates/profile.template.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Profile template for ClaudeBox
+# Copy this file to create a new profile
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        # Return profile name and description separated by |
+        printf '%s|%s\n' "PROFILE_NAME" "Profile description here"
+        ;;
+    packages)
+        # Return space-separated list of apt packages to install
+        # Leave empty if no packages needed
+        printf '%s\n' ""
+        ;;
+    dockerfile)
+        # Output Dockerfile RUN commands for this profile
+        # Can be multiple lines, will be inserted into Dockerfile
+        cat << 'EOF'
+# Profile-specific Docker commands here
+# RUN apt-get update && apt-get install -y something
+EOF
+        ;;
+    depends)
+        # Return space-separated list of profile dependencies
+        # Common dependencies: core, build-tools
+        printf '%s\n' ""
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/build-tools.sh
+++ b/tooling/profiles/build-tools.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build tools profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "build-tools" "Build Tools (CMake, autotools, Ninja)"
+        ;;
+    packages)
+        printf '%s\n' "cmake ninja-build autoconf automake libtool"
+        ;;
+    dockerfile)
+        packages="cmake ninja-build autoconf automake libtool"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' ""
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/c.sh
+++ b/tooling/profiles/c.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# C/C++ development profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "c" "C/C++ Development (debuggers, analyzers, Boost, ncurses, cmocka)"
+        ;;
+    packages)
+        printf '%s\n' "gdb valgrind clang clang-format clang-tidy cppcheck doxygen libboost-all-dev libcmocka-dev libcmocka0 lcov libncurses5-dev libncursesw5-dev"
+        ;;
+    dockerfile)
+        packages="gdb valgrind clang clang-format clang-tidy cppcheck doxygen libboost-all-dev libcmocka-dev libcmocka0 lcov libncurses5-dev libncursesw5-dev"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core build-tools"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/core.sh
+++ b/tooling/profiles/core.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Core profile for ClaudeBox - Essential development utilities
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "core" "Core Development Utilities (compilers, VCS, shell tools)"
+        ;;
+    packages)
+        printf '%s\n' "gcc g++ make git pkg-config libssl-dev libffi-dev zlib1g-dev tmux"
+        ;;
+    dockerfile)
+        packages="gcc g++ make git pkg-config libssl-dev libffi-dev zlib1g-dev tmux"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        # Core has no dependencies, it's the base
+        printf '%s\n' ""
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/database.sh
+++ b/tooling/profiles/database.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Database tools profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "database" "Database Tools (clients for major databases)"
+        ;;
+    packages)
+        printf '%s\n' "postgresql-client mysql-client sqlite3 redis-tools mongodb-clients"
+        ;;
+    dockerfile)
+        packages="postgresql-client mysql-client sqlite3 redis-tools mongodb-clients"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/datascience.sh
+++ b/tooling/profiles/datascience.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Data Science profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "datascience" "Data Science (Python, Jupyter, R)"
+        ;;
+    packages)
+        printf '%s\n' "r-base"
+        ;;
+    dockerfile)
+        packages="r-base"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/devops.sh
+++ b/tooling/profiles/devops.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# DevOps tools profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "devops" "DevOps Tools (Docker, Kubernetes, Terraform, etc.)"
+        ;;
+    packages)
+        printf '%s\n' "docker.io docker-compose kubectl helm terraform ansible awscli"
+        ;;
+    dockerfile)
+        packages="docker.io docker-compose kubectl helm terraform ansible awscli"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/embedded.sh
+++ b/tooling/profiles/embedded.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Embedded development profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "embedded" "Embedded Dev (ARM toolchain, serial debuggers)"
+        ;;
+    packages)
+        printf '%s\n' "gcc-arm-none-eabi gdb-multiarch openocd picocom minicom screen"
+        ;;
+    dockerfile)
+        cat << 'EOF'
+RUN apt-get update && apt-get install -y gcc-arm-none-eabi gdb-multiarch openocd picocom minicom screen && apt-get clean
+USER claude
+RUN ~/.local/bin/uv tool install platformio
+USER root
+EOF
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/go.sh
+++ b/tooling/profiles/go.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
-# Rust profile for ClaudeBox
+# Go development profile for ClaudeBox
 set -euo pipefail
 
 case "${1:-}" in
     info)
-        printf '%s|%s\n' "rust" "Rust Development (installed via rustup)"
+        printf '%s|%s\n' "go" "Go Development (installed from upstream archive)"
         ;;
     packages)
-        # Rust doesn't need apt packages, installed via rustup
+        # Go is installed from tarball, not apt
         printf '%s\n' ""
         ;;
     dockerfile)
         cat << 'EOF'
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/home/claude/.cargo/bin:$PATH"
+RUN wget -O go.tar.gz https://golang.org/dl/go1.21.0.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+ENV PATH="/usr/local/go/bin:$PATH"
 EOF
         ;;
     depends)
-        # Rust benefits from core utilities
         printf '%s\n' "core"
         ;;
     *)

--- a/tooling/profiles/java.sh
+++ b/tooling/profiles/java.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Java development profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "java" "Java Development (OpenJDK 17, Maven, Gradle, Ant)"
+        ;;
+    packages)
+        printf '%s\n' "openjdk-17-jdk maven gradle ant"
+        ;;
+    dockerfile)
+        packages="openjdk-17-jdk maven gradle ant"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/javascript.sh
+++ b/tooling/profiles/javascript.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# JavaScript/TypeScript development profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "javascript" "JavaScript/TypeScript (Node installed via nvm)"
+        ;;
+    packages)
+        # JavaScript tools installed via nvm/npm, not apt
+        printf '%s\n' ""
+        ;;
+    dockerfile)
+        cat << 'EOF'
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+ENV NVM_DIR="/home/claude/.nvm"
+RUN . $NVM_DIR/nvm.sh && nvm install --lts
+USER claude
+RUN bash -c "source $NVM_DIR/nvm.sh && npm install -g typescript eslint prettier yarn pnpm"
+USER root
+EOF
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/ml.sh
+++ b/tooling/profiles/ml.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Machine Learning profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "ml" "Machine Learning (build layer only; Python via uv)"
+        ;;
+    packages)
+        # ML profile just needs build tools which are dependencies
+        printf '%s\n' ""
+        ;;
+    dockerfile)
+        # ML profile uses build-tools for compilation
+        printf '%s\n' "# ML profile uses build-tools for compilation"
+        ;;
+    depends)
+        printf '%s\n' "core build-tools"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/networking.sh
+++ b/tooling/profiles/networking.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Networking tools profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "networking" "Network Tools (IP stack, DNS, route tools)"
+        ;;
+    packages)
+        printf '%s\n' "iptables ipset iproute2 dnsutils"
+        ;;
+    dockerfile)
+        packages="iptables ipset iproute2 dnsutils"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' ""
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/openwrt.sh
+++ b/tooling/profiles/openwrt.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# OpenWRT development profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "openwrt" "OpenWRT Development (cross toolchain, QEMU, distro tools)"
+        ;;
+    packages)
+        printf '%s\n' "rsync libncurses5-dev zlib1g-dev gawk gettext xsltproc libelf-dev ccache subversion swig time qemu-system-arm qemu-system-aarch64 qemu-system-mips qemu-system-x86 qemu-utils"
+        ;;
+    dockerfile)
+        packages="rsync libncurses5-dev zlib1g-dev gawk gettext xsltproc libelf-dev ccache subversion swig time qemu-system-arm qemu-system-aarch64 qemu-system-mips qemu-system-x86 qemu-utils"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core build-tools"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/php.sh
+++ b/tooling/profiles/php.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PHP development profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "php" "PHP Development (PHP + extensions + Composer)"
+        ;;
+    packages)
+        printf '%s\n' "php php-cli php-fpm php-mysql php-pgsql php-sqlite3 php-curl php-gd php-mbstring php-xml php-zip composer"
+        ;;
+    dockerfile)
+        packages="php php-cli php-fpm php-mysql php-pgsql php-sqlite3 php-curl php-gd php-mbstring php-xml php-zip composer"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/python.sh
+++ b/tooling/profiles/python.sh
@@ -1,23 +1,22 @@
 #!/usr/bin/env bash
-# Rust profile for ClaudeBox
+# Python development profile for ClaudeBox
 set -euo pipefail
 
 case "${1:-}" in
     info)
-        printf '%s|%s\n' "rust" "Rust Development (installed via rustup)"
+        printf '%s|%s\n' "python" "Python Development (managed via uv)"
         ;;
     packages)
-        # Rust doesn't need apt packages, installed via rustup
+        # Python packages are managed via uv, not apt
         printf '%s\n' ""
         ;;
     dockerfile)
         cat << 'EOF'
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/home/claude/.cargo/bin:$PATH"
+# Python profile - uv already installed in base image
+# Python venv and dev tools are managed via entrypoint flag system
 EOF
         ;;
     depends)
-        # Rust benefits from core utilities
         printf '%s\n' "core"
         ;;
     *)

--- a/tooling/profiles/ruby.sh
+++ b/tooling/profiles/ruby.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Ruby development profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "ruby" "Ruby Development (gems, native deps, XML/YAML)"
+        ;;
+    packages)
+        printf '%s\n' "ruby-full ruby-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common"
+        ;;
+    dockerfile)
+        packages="ruby-full ruby-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/rust.sh
+++ b/tooling/profiles/rust.sh
@@ -12,8 +12,35 @@ case "${1:-}" in
         ;;
     dockerfile)
         cat << 'EOF'
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# Install Rust via rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
 ENV PATH="/home/claude/.cargo/bin:$PATH"
+ENV RUSTUP_HOME="/home/claude/.rustup"
+ENV CARGO_HOME="/home/claude/.cargo"
+
+# Install Rust components
+RUN /home/claude/.cargo/bin/rustup component add rust-src rust-analyzer clippy rustfmt llvm-tools-preview
+
+# Install essential cargo tools
+RUN /home/claude/.cargo/bin/cargo install \
+    cargo-edit \
+    cargo-watch \
+    cargo-expand \
+    cargo-outdated \
+    cargo-audit \
+    cargo-deny \
+    cargo-tree \
+    cargo-bloat \
+    cargo-flamegraph \
+    cargo-tarpaulin \
+    cargo-criterion \
+    cargo-release \
+    cargo-make \
+    sccache \
+    bacon \
+    just \
+    tokei \
+    hyperfine
 EOF
         ;;
     depends)

--- a/tooling/profiles/security.sh
+++ b/tooling/profiles/security.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Security tools profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "security" "Security Tools (scanners, crackers, packet tools)"
+        ;;
+    packages)
+        printf '%s\n' "nmap tcpdump wireshark-common netcat-openbsd john hashcat hydra"
+        ;;
+    dockerfile)
+        packages="nmap tcpdump wireshark-common netcat-openbsd john hashcat hydra"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/shell.sh
+++ b/tooling/profiles/shell.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shell tools profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "shell" "Optional Shell Tools (fzf, SSH, man, rsync, file)"
+        ;;
+    packages)
+        printf '%s\n' "rsync openssh-client man-db gnupg2 aggregate file"
+        ;;
+    dockerfile)
+        packages="rsync openssh-client man-db gnupg2 aggregate file"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' ""
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac

--- a/tooling/profiles/web.sh
+++ b/tooling/profiles/web.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Web development tools profile for ClaudeBox
+set -euo pipefail
+
+case "${1:-}" in
+    info)
+        printf '%s|%s\n' "web" "Web Dev Tools (nginx, HTTP test clients)"
+        ;;
+    packages)
+        printf '%s\n' "nginx apache2-utils httpie"
+        ;;
+    dockerfile)
+        packages="nginx apache2-utils httpie"
+        if [[ -n "$packages" ]]; then
+            printf 'RUN apt-get update && apt-get install -y %s && apt-get clean\n' "$packages"
+        fi
+        ;;
+    depends)
+        printf '%s\n' "core"
+        ;;
+    *)
+        printf 'Usage: %s {info|packages|dockerfile|depends}\n' "$0" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
- Migrate all 20 hardcoded profiles to standalone scripts in /workspace/tooling/profiles/
- Create dynamic loader functions that scan directories for profile scripts
- Add support for user custom profiles in ~/.claudebox/profiles/
- Implement new profile management commands:
  - claudebox profile create <name> - Create custom profile from template
  - claudebox profile install <path/url> - Install profile from file or URL
- Add profile template at templates/profile.template.sh
- Maintain backward compatibility with legacy function wrappers
- Each profile script supports standard commands: info, packages, dockerfile, depends
- Enhanced profiles listing shows system vs user profiles separately
- Add security checks when installing external profiles
- Implement automatic dependency resolution via 'depends' command

This change allows users to add custom profiles without modifying ClaudeBox core code, making the system fully extensible while preserving all existing functionality.

## Summary by Sourcery

Add a dynamic profile system to replace hardcoded profiles and enable extensibility

New Features:
- Load profile scripts dynamically from system and user directories
- Allow users to create and install custom profiles via new CLI commands
- Provide a profile template for easy custom profile creation

Enhancements:
- Maintain backward compatibility with legacy profile functions
- Separate system and user profiles in listing output
- Automatically resolve profile dependencies during expansion