### PR TITLE
feat: add flutter profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ claudebox profile rust go         # Rust + Go
 - **rust** - Rust Development (installed via rustup)
 - **python** - Python Development (managed via uv)
 - **go** - Go Development (installed from upstream archive)
+- **flutter** - Flutter Framework (installed using fvm, use FLUTTER_SDK_VERSION to set different version)
 - **javascript** - JavaScript/TypeScript (Node installed via nvm)
 - **java** - Java Development (OpenJDK 17, Maven, Gradle, Ant)
 - **ruby** - Ruby Development (gems, native deps, XML/YAML)

--- a/lib/commands.info.sh
+++ b/lib/commands.info.sh
@@ -164,7 +164,7 @@ _cmd_info() {
         echo -e "   Status:     ${YELLOW}No profiles installed${NC}"
     fi
 
-    echo -e "   Available:  ${CYAN}core${NC}, python, c, rust, go, javascript, java, ruby, php"
+    echo -e "   Available:  ${CYAN}core${NC}, python, c, rust, go, flutter, javascript, java, ruby, php"
     echo -e "               database, devops, web, ml, security, embedded, networking"
     echo -e "   ${CYAN}Hint:${NC} Run 'claudebox profile' for profile help "
     echo

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -265,6 +265,7 @@ RUN fvm install $flutter_version
 RUN fvm global $flutter_version
 ENV PATH="/home/claude/fvm/default/bin:$PATH"
 RUN flutter doctor
+USER root
 EOF
 }
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -261,8 +261,8 @@ get_profile_flutter() {
 USER claude
 RUN curl -fsSL https://fvm.app/install.sh | bash
 ENV PATH="/usr/local/bin:$PATH"
-RUN fvm install $flutter_version \
-    fvm global $flutter_version
+RUN fvm install $flutter_version
+RUN fvm global $flutter_version
 ENV PATH="/home/claude/fvm/default/bin:$PATH"
 RUN flutter doctor
 EOF

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -23,6 +23,7 @@ get_profile_packages() {
         rust) echo "" ;;  # Rust installed via rustup
         python) echo "" ;;  # Managed via uv
         go) echo "" ;;  # Installed from tarball
+        flutter) echo "" ;;  # Installed from source
         javascript) echo "" ;;  # Installed via nvm
         java) echo "openjdk-17-jdk maven gradle ant" ;;
         ruby) echo "ruby-full ruby-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common" ;;
@@ -49,6 +50,7 @@ get_profile_description() {
         rust) echo "Rust Development (installed via rustup)" ;;
         python) echo "Python Development (managed via uv)" ;;
         go) echo "Go Development (installed from upstream archive)" ;;
+        flutter) echo "Flutter Development (installed from fvm)" ;;
         javascript) echo "JavaScript/TypeScript (Node installed via nvm)" ;;
         java) echo "Java Development (OpenJDK 17, Maven, Gradle, Ant)" ;;
         ruby) echo "Ruby Development (gems, native deps, XML/YAML)" ;;
@@ -65,7 +67,7 @@ get_profile_description() {
 }
 
 get_all_profile_names() {
-    echo "core build-tools shell networking c openwrt rust python go javascript java ruby php database devops web embedded datascience security ml"
+    echo "core build-tools shell networking c openwrt rust python go flutter javascript java ruby php database devops web embedded datascience security ml"
 }
 
 profile_exists() {
@@ -81,7 +83,7 @@ expand_profile() {
         c) echo "core build-tools c" ;;
         openwrt) echo "core build-tools openwrt" ;;
         ml) echo "core build-tools ml" ;;
-        rust|go|python|php|ruby|java|database|devops|web|embedded|datascience|security|javascript)
+        rust|go|flutter|python|php|ruby|java|database|devops|web|embedded|datascience|security|javascript)
             echo "core $1"
             ;;
         shell|networking|build-tools|core)
@@ -253,6 +255,19 @@ ENV PATH="/usr/local/go/bin:$PATH"
 EOF
 }
 
+get_profile_flutter() {
+    local flutter_version="${FLUTTER_SDK_VERSION:-stable}"
+    cat << EOF
+USER claude
+RUN curl -fsSL https://fvm.app/install.sh | bash
+ENV PATH="/usr/local/bin:$PATH"
+RUN fvm install $flutter_version \
+    fvm global $flutter_version
+ENV PATH="/home/claude/fvm/default/bin:$PATH"
+RUN flutter doctor
+EOF
+}
+
 get_profile_javascript() {
     cat << 'EOF'
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
@@ -340,6 +355,6 @@ get_profile_ml() {
 export -f _read_ini get_profile_packages get_profile_description get_all_profile_names profile_exists expand_profile
 export -f get_profile_file_path read_config_value read_profile_section update_profile_section get_current_profiles
 export -f get_profile_core get_profile_build_tools get_profile_shell get_profile_networking get_profile_c get_profile_openwrt
-export -f get_profile_rust get_profile_python get_profile_go get_profile_javascript get_profile_java get_profile_ruby
+export -f get_profile_rust get_profile_python get_profile_go get_profile_flutter get_profile_javascript get_profile_java get_profile_ruby
 export -f get_profile_php get_profile_database get_profile_devops get_profile_web get_profile_embedded get_profile_datascience
 export -f get_profile_security get_profile_ml

--- a/lib/tools-report.sh
+++ b/lib/tools-report.sh
@@ -227,6 +227,19 @@ _describe_profile() {
             echo
             ;;
             
+        flutter)
+            echo "**Flutter Framework**"
+            echo
+            echo Use FLUTTER_SDK_VERSION environment variable before running claudebox to set use different flutter version
+            echo Ex: FLUTTER_SDK_VERSION=beta claudebox
+            echo
+            echo "Available commands:"
+            echo "- flutter - To manage flutter apps"
+            echo "- dart - To run dart cli tasks"
+            echo "- fvm - To manage flutter versions"
+            echo
+            ;;
+            
         c)
             echo "**C/C++ Advanced Development**"
             echo


### PR DESCRIPTION
Adds flutter as a profile, default to stable flutter version but can be modified when initializing claudebox:
`FLUTTER_SDK_VERSION=beta claudebox`

I would've want a variable in profile to manage this better so people can do:
`claudebox add flutter --version=beta`

But current there is no syntax like that so used an environment variable instead.

## Summary by Sourcery

Introduce a flutter profile to claudebox that installs Flutter using fvm, defaulting to the stable channel with version overrides via an environment variable, and update configuration, help commands, and documentation accordingly.

New Features:
- Add flutter development profile installed via fvm

Enhancements:
- Allow customizing Flutter SDK version via FLUTTER_SDK_VERSION environment variable

Documentation:
- Update README and CLI help outputs to include flutter profile
- Add flutter help section in tools-report