### PR TITLE
fix: line 304 user_mcp_file: unbound variable

### DIFF
--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -301,10 +301,10 @@ run_claudebox_container() {
                 rm -f "$file"
             fi
         done
-        if [[ -n "$user_mcp_file" ]] && [[ -f "$user_mcp_file" ]]; then
+        if [[ -n "${user_mcp_file:-}" ]] && [[ -f "${user_mcp_file:-}" ]]; then
             rm -f "$user_mcp_file"
         fi
-        if [[ -n "$project_mcp_file" ]] && [[ -f "$project_mcp_file" ]]; then
+        if [[ -n "${project_mcp_file:-}" ]] && [[ -f "${project_mcp_file:-}" ]]; then
             rm -f "$project_mcp_file"
         fi
     }


### PR DESCRIPTION
Whenever I am exiting claudebox it is giving this error. This PR gives a default value to that variable as empty and fixes this issue. Issue is reproducible on main.

## Summary by Sourcery

Bug Fixes:
- Use default empty expansions for user_mcp_file and project_mcp_file to avoid unbound variable errors