### PR TITLE
feat: Upgrade Java profile to use SDKMan for latest LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ claudebox profile rust go         # Rust + Go
 - **python** - Python Development (managed via uv)
 - **go** - Go Development (installed from upstream archive)
 - **javascript** - JavaScript/TypeScript (Node installed via nvm)
-- **java** - Java Development (OpenJDK 17, Maven, Gradle, Ant)
+- **java** - Java Development (Latest LTS via SDKMan, Maven, Gradle, Ant)
 - **ruby** - Ruby Development (gems, native deps, XML/YAML)
 - **php** - PHP Development (PHP + extensions + Composer)
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg]" \
     "https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && apt-get update && \
-        apt-get install -y --no-autoremove --no-install-recommends apt-utils wget zsh fzf ca-certificates sudo git tmux iptables ipset gh unzip jq \
+        apt-get install -y --no-autoremove --no-install-recommends apt-utils wget zsh fzf ca-certificates sudo git tmux iptables ipset gh zip unzip jq \
         procps vim nano less iputils-ping traceroute dnsutils netcat-openbsd net-tools xdg-utils
 
 ENV LANG=en_US.UTF-8 \

--- a/lib/tools-report.sh
+++ b/lib/tools-report.sh
@@ -249,10 +249,10 @@ _describe_profile() {
             echo "**Java Development Environment**"
             echo
             echo "Java development tools:"
-            echo "- OpenJDK 17 - Java Development Kit"
-            echo "- Maven - Build automation and dependency management"
-            echo "- Gradle - Build automation system"
-            echo "- Ant - Build tool"
+            echo "- Java - Latest JDK LTS installed via SDKMan"
+            echo "- Maven - Build automation and dependency management (via SDKMan)"
+            echo "- Gradle - Build automation system (via SDKMan)"
+            echo "- Ant - Build tool (via SDKMan)"
             echo
             ;;
             


### PR DESCRIPTION
## Summary

This PR modernizes the Java development profile by migrating from static OpenJDK 17 packages to SDKMan, enabling automatic use of the latest Java LTS version.

## Motivation

- Users reported wanting Java 21+ features (see issue #45 comments)
- The previous implementation was locked to Java 17, which is now outdated
- Other language profiles (Node via nvm, Rust via rustup) already use version managers
- SDKMan is the de facto standard for Java version management

## Changes

### 1. Base Docker Image
- Added `zip` package alongside existing `unzip` (required by SDKMan)

### 2. Java Profile Rewrite
- Replaced apt package installation with SDKMan
- Java, Maven, Gradle, and Ant all installed via SDKMan
- Installs as `claude` user (following SDKMan's user-space design)
- Creates system-wide symlinks for all tools
- Sets `JAVA_HOME` and `PATH` environment variables

### 3. Documentation Updates
- README now shows "Latest LTS via SDKMan" instead of "OpenJDK 17"
- Tools report updated to reflect SDKMan-based installations

## Benefits

✅ **Always Current**: Automatically gets latest Java LTS (currently 21, soon 25)
✅ **Better Integration**: Maven/Gradle/Ant managed together with Java
✅ **Consistency**: Follows same pattern as JavaScript (nvm) and Rust (rustup) profiles
✅ **Future-proof**: New LTS versions available without code changes
✅ **User-friendly**: SDKMan handles all PATH and JAVA_HOME configuration

## Alternative Approach Considered

An alternative solution would be to source SDKMan's init script in the docker-entrypoint file, similar to how nvm is handled. This would involve:

1. Adding to `build/docker-entrypoint` around lines 140-150 (where nvm is sourced):
```bash
export SDKMAN_DIR="$HOME/.sdkman"
if [[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]]; then
    \. "$SDKMAN_DIR/bin/sdkman-init.sh"
else
    echo "Warning: SDKMan not found at $SDKMAN_DIR" >&2
fi
```

2. Removing the symlink creation and ENV PATH setup from the Java profile (lines 273-282 in lib/config.sh)

This approach would be shorter and follow nvm's pattern exactly. However, we chose the current implementation because:
- It keeps all Java-related setup contained within the Java profile
- It doesn't require modifications to the core docker-entrypoint file
- System-wide symlinks ensure Java tools work even in non-interactive shells
- It's more explicit about what's being installed and where

## Testing

The changes have been tested locally:
- Java profile builds successfully
- `java -version` shows Java 21
- Maven, Gradle, and Ant are all accessible
- JAVA_HOME is properly set

## Breaking Changes

None. Users with existing Java profiles will get the new version on next rebuild.

## References

- Related to discussion in #45 about Java version requirements
- Follows established patterns from JavaScript and Rust profiles

🤖 Generated with Claude Code

## Summary by Sourcery

Upgrade the Java development profile to install Java, Maven, Gradle, and Ant via SDKMan for automatic latest LTS support, add necessary dependencies, and update documentation and reports accordingly.

New Features:
- Migrate Java, Maven, Gradle, and Ant installation to SDKMan under the ‘claude’ user with system-wide symlinks and environment variables
- Add the zip package to the base Docker image to satisfy SDKMan prerequisites

Documentation:
- Update README to describe the Java profile as using SDKMan for latest LTS
- Update tools-report to list Java tools installed via SDKMan