### PR TITLE
Mount user's .gitconfig read-only in containers

### DIFF
--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -242,6 +242,14 @@ run_claudebox_container() {
     # Mount SSH directory
     docker_args+=(-v "$HOME/.ssh":"/home/$DOCKER_USER/.ssh:ro")
     
+    # Mount git config if it exists
+    if [[ -f "$HOME/.gitconfig" ]]; then
+        docker_args+=(-v "$HOME/.gitconfig:/home/$DOCKER_USER/.gitconfig:ro")
+        if [[ "$VERBOSE" == "true" ]]; then
+            echo "[DEBUG] Mounting git config (r/o): $HOME/.gitconfig" >&2
+        fi
+    fi
+    
     # Mount .env file if it exists in the project directory
     if [[ -f "$PROJECT_DIR/.env" ]]; then
         docker_args+=(-v "$PROJECT_DIR/.env":/workspace/.env:ro)


### PR DESCRIPTION
- Automatically mount ~/.gitconfig as read-only when it exists
- Includes verbose debug logging when enabled

## Summary by Sourcery

Automatically mount the user’s ~/.gitconfig as read-only inside the Docker container when present, and provide optional debug logging for the mount step.

New Features:
- Mount the host user’s ~/.gitconfig as a read-only volume in the container if it exists.
- Emit a debug log message when verbose mode is enabled for the gitconfig mount step.