### PR TITLE
Add flexible SSH directory mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ claudebox rebuild
 ClaudeBox stores data in:
 - `~/.claude/` - Global Claude configuration (mounted read-only)
 - `~/.claudebox/` - Global ClaudeBox data
+- `~/.claudebox/ssh/` - ClaudeBox SSH keys
 - `~/.claudebox/profiles/` - Per-project profile configurations (*.ini files)
 - `~/.claudebox/<project-name>/` - Project-specific data:
   - `.claude/` - Project auth state
@@ -360,6 +361,34 @@ ClaudeBox stores data in:
   - `.config/` - Tool configurations
   - `firewall/allowlist` - Network allowlist
 - Current directory mounted as `/workspace` in container
+
+### SSH Key Configuration
+
+ClaudeBox provides flexible SSH key mounting:
+
+**ClaudeBox SSH Directory (Recommended)**
+- Uses dedicated SSH keys in `~/.claudebox/ssh/`.
+- This directory is mounted **read-write** when it exists
+- Enables persistent `known_hosts` updates
+
+**Default Mode (Backwards Compatible)**
+- Mounts `~/.ssh` as **read-only** by default
+- SSH keys work for cloning and authentication
+- `known_hosts` changes are not persisted between sessions
+
+To set up ClaudeBox SSH directory:
+```bash
+# Create the directory
+mkdir -p ~/.claudebox/ssh
+chmod 700 ~/.claudebox/ssh
+
+# Copy existing SSH config (optional)
+cp ~/.ssh/config ~/.claudebox/ssh/
+cp ~/.ssh/known_hosts ~/.claudebox/ssh/
+
+# Generate a dedicated key for ClaudeBox
+ssh-keygen -t ed25519 -f ~/.claudebox/ssh/id_ed25519 -C "claudebox@$(hostname)"
+```
 
 ### Project-Specific Features
 


### PR DESCRIPTION
- Mount ~/.claudebox/ssh read-write when it exists for persistent SSH state
- Fall back to ~/.ssh read-only for backwards compatibility
- Documentation with setup instructions for dedicated ClaudeBox SSH keys

## Summary by Sourcery

Enable flexible SSH key mounting by preferring a dedicated ~/.claudebox/ssh directory with read-write access and falling back to ~/.ssh as read-only, and update documentation with setup instructions

New Features:
- Add support for mounting ~/.claudebox/ssh into containers as a read-write directory for persistent SSH state

Enhancements:
- Fallback to mounting the user’s ~/.ssh directory as read-only when no ClaudeBox SSH directory exists

Documentation:
- Add README section explaining SSH directory configuration and setup for ClaudeBox keys