### PR TITLE
feat: Pass environment variables from .env file to container

### DIFF
--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -245,8 +245,10 @@ run_claudebox_container() {
     # Mount .env file if it exists in the project directory
     if [[ -f "$PROJECT_DIR/.env" ]]; then
         docker_args+=(-v "$PROJECT_DIR/.env":/workspace/.env:ro)
+        # Also pass the environment variables from the .env file
+        docker_args+=(--env-file "$PROJECT_DIR/.env")
         if [[ "$VERBOSE" == "true" ]]; then
-            echo "[DEBUG] Mounting .env file from project directory" >&2
+            echo "[DEBUG] Mounting and loading .env file from project directory" >&2
         fi
     fi
     


### PR DESCRIPTION
Add --env-file option to docker run command when .env file exists in the project directory. This allows environment variables defined in .env to be automatically available inside the container.

The .env file was already being mounted, but variables weren't being loaded. This simple change adds the --env-file flag to make Docker parse and load all variables from the file.

## Summary by Sourcery

New Features:
- Pass environment variables from .env into the Docker container using the --env-file flag