### PR TITLE
Fix MCP cleanup trap scoping issue causing exit errors

### DIFF
--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -296,17 +296,11 @@ run_claudebox_container() {
     # Set up cleanup trap for temporary MCP config files
     cleanup_mcp_files() {
         local file
-        for file in "${mcp_temp_files[@]}"; do
+        for file in "${mcp_temp_files[@]:-}"; do
             if [[ -f "$file" ]]; then
                 rm -f "$file"
             fi
         done
-        if [[ -n "$user_mcp_file" ]] && [[ -f "$user_mcp_file" ]]; then
-            rm -f "$user_mcp_file"
-        fi
-        if [[ -n "$project_mcp_file" ]] && [[ -f "$project_mcp_file" ]]; then
-            rm -f "$project_mcp_file"
-        fi
     }
     trap cleanup_mcp_files EXIT
     
@@ -315,6 +309,7 @@ run_claudebox_container() {
         user_mcp_file=$(create_mcp_config_file "$HOME/.claude.json" "")
         
         if [[ -n "$user_mcp_file" ]]; then
+            mcp_temp_files+=("$user_mcp_file")
             local user_count=$(jq '.mcpServers | length' "$user_mcp_file" 2>/dev/null || echo "0")
             if [[ "$user_count" -gt 0 ]]; then
                 if [[ "$VERBOSE" == "true" ]]; then
@@ -358,6 +353,7 @@ run_claudebox_container() {
     local project_count=$(jq '.mcpServers | length' "$temp_project_file" 2>/dev/null || echo "0")
     if [[ "$project_count" -gt 0 ]]; then
         project_mcp_file="$temp_project_file"
+        # Note: temp_project_file already added to mcp_temp_files above
         if [[ "$VERBOSE" == "true" ]]; then
             printf "Found %s project MCP servers\n" "$project_count" >&2
         fi


### PR DESCRIPTION
Fixes #72

## Summary

This PR fixes the bash "unbound variable" errors that occur when ClaudeBox exits with MCP servers configured. The issue was caused by EXIT traps not having access to local variables from the function where they're defined.

## Changes Made

- Simplified `cleanup_mcp_files()` to only use `mcp_temp_files` array
- Added `user_mcp_file` to `mcp_temp_files` array for proper cleanup tracking
- Added parameter expansion safety (`${mcp_temp_files[@]:-}`) to handle empty arrays
- Removed direct variable access in cleanup function that caused scoping issues

## Technical Details

The core issue was that EXIT traps execute in a different context where function-local variables are not accessible:

```bash
run_claudebox_container() {
    local user_mcp_file=""      # Function-scoped
    local project_mcp_file=""   # Function-scoped

    cleanup_mcp_files() {
        # Trap runs when script exits - function scope is gone!
        if [[ -n "$user_mcp_file" ]]; then  # ERROR: unbound variable
            rm -f "$user_mcp_file"
        fi
    }
    trap cleanup_mcp_files EXIT
}
```

The fix ensures all temporary files are tracked in the `mcp_temp_files` array which is accessible to the EXIT trap, eliminating the scoping issue entirely.

## Testing

- ✅ Bash syntax validation passes (`bash -n lib/docker.sh`)
- ✅ No more "unbound variable" errors on exit
- ✅ All MCP temp files still cleaned up properly
- ✅ Exit code 0 instead of 1

## Impact

- Fixes user-visible errors on every ClaudeBox exit with MCP servers
- Resolves exit code 1 that can break scripts and automation
- Improves reliability of the cleanup process
- Fully backwards compatible - only improves the cleanup mechanism

The fix eliminates a bash scoping anti-pattern and makes the cleanup process more predictable and maintainable.

## Summary by Sourcery

Fix trap scoping issue in cleanup_mcp_files by consolidating MCP temp files into a single array accessible to the EXIT trap, eliminating unbound variable errors and restoring exit code 0.

Bug Fixes:
- Avoid bash "unbound variable" errors on exit by removing direct access to function-scoped variables in the cleanup trap
- Restore exit code 0 by ensuring cleanup_mcp_files always runs without error

Enhancements:
- Simplify cleanup_mcp_files to iterate solely over mcp_temp_files with safe parameter expansion
- Add user and project MCP config files to mcp_temp_files array for consistent tracking and removal