### PR TITLE
fix: mount .local/share to persist uv-managed Python installations

### DIFF
--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -239,6 +239,11 @@ run_claudebox_container() {
     # Mount .cache directory
     docker_args+=(-v "$PROJECT_SLOT_DIR/.cache":/home/$DOCKER_USER/.cache)
     
+    # Mount .local/share for uv-managed Python installations
+    # uv downloads Python to ~/.local/share/uv/python/ which must persist across containers
+    mkdir -p "$PROJECT_SLOT_DIR/.local/share"
+    docker_args+=(-v "$PROJECT_SLOT_DIR/.local/share":/home/$DOCKER_USER/.local/share)
+    
     # Mount SSH directory
     docker_args+=(-v "$HOME/.ssh":"/home/$DOCKER_USER/.ssh:ro")
     


### PR DESCRIPTION
## Description

Fixes broken Python venv symlinks after container restarts by mounting `~/.local/share/` to persist uv-managed Python installations.

Fixes #87

## Problem

When `uv` creates a venv with `--python-preference managed`, it downloads Python to `~/.local/share/uv/python/`. The venv contains symlinks pointing to this location, but since `~/.local/share/` was not mounted, the Python installation was lost on container exit, leaving broken symlinks.

## Solution

Added mount for `PROJECT_SLOT_DIR/.local/share` in `lib/docker.sh` to persist uv-downloaded Python installations across container restarts.

```diff
+    # Mount .local/share for uv-managed Python installations
+    # uv downloads Python to ~/.local/share/uv/python/ which must persist across containers
+    mkdir -p "$PROJECT_SLOT_DIR/.local/share"
+    docker_args+=(-v "$PROJECT_SLOT_DIR/.local/share":/home/$DOCKER_USER/.local/share)
```

## Testing

Tested on macOS with ml-tutorial project:

1. ✅ Clean project, add `python ml` profiles
2. ✅ First run: Python 3.14 downloads successfully (111 packages including torch, transformers, scikit-learn, pandas, numpy)
3. ✅ Verified Python installation persists on host: `~/.claudebox/projects/.../6111fd25/.local/share/uv/python/cpython-3.14.0-linux-aarch64-gnu/`
4. ✅ Venv symlinks are valid and point to persisted Python
5. ✅ Subsequent container starts: Python works correctly

## Impact

- Affects: `python`, `ml`, and `datascience` profiles
- Compatibility: macOS and Linux
- Breaking changes: None
- Performance: Negligible (adds one directory mount)

## Related Issues

This bug was introduced in commit [`57fa079`](https://github.com/RchGrav/claudebox/commit/57fa079) when Python installation was moved from build-time to runtime.

Subsequent commits attempted to fix Python issues but missed the root cause:
- `4fd05a8` - "Fix multiple issues: shell auth, Python/uv PATH..."
- `b2aedd9` - "Fix multiple issues with Python/uv, tmux activation..."
- `bcf4ee7` - "Add UV_PYTHON_MANAGED=1 environment variable"

