### PR TITLE
fix: Bash 3.2 compatibility with set -u flag

### DIFF
--- a/build/docker-entrypoint
+++ b/build/docker-entrypoint
@@ -83,7 +83,7 @@ if [ -n "${CLAUDEBOX_PROJECT_NAME:-}" ]; then
                     runuser -u DOCKERUSER -- touch "$VENV_FLAG"
                 else
                     # Someone else is fixing it, wait for completion
-                    local wait_count=0
+                    wait_count=0
                     while [ ! -f "$VENV_FLAG" ] && [ $wait_count -lt 60 ]; do
                         sleep 0.5
                         ((wait_count++)) || true
@@ -106,7 +106,7 @@ if [ -n "${CLAUDEBOX_PROJECT_NAME:-}" ]; then
                     runuser -u DOCKERUSER -- touch "$VENV_FLAG"
                 else
                     # Someone else is creating it, wait for completion flag
-                    local wait_count=0
+                    wait_count=0
                     while [ ! -f "$VENV_FLAG" ] && [ $wait_count -lt 60 ]; do
                         sleep 0.5
                         ((wait_count++)) || true
@@ -138,7 +138,7 @@ if [ -n "${CLAUDEBOX_PROJECT_NAME:-}" ]; then
         if [ -f "$CONFIG_FILE" ] && grep -qE 'python|ml|datascience' "$CONFIG_FILE"; then
             if [ ! -f "$PYDEV_FLAG" ] && [ -f "$VENV_FLAG" ] && [ -d "$VENV_DIR" ]; then
                 # Deploy Python dev tools based on profile
-                local python_packages=""
+                python_packages=""
                 
                 # Base Python profile packages
                 if grep -q 'python' "$CONFIG_FILE"; then

--- a/lib/commands.core.sh
+++ b/lib/commands.core.sh
@@ -113,11 +113,11 @@ _cmd_shell() {
         trap cleanup_admin EXIT
         
         if [[ "$VERBOSE" == "true" ]]; then
-            echo "[DEBUG] Running admin container with flags: ${shell_flags[*]}" >&2
+            echo "[DEBUG] Running admin container with flags: ${shell_flags[*]+"${shell_flags[*]}"}" >&2
             echo "[DEBUG] Remaining args after processing: $*" >&2
         fi
         # Don't pass any remaining arguments - only shell and the flags
-        run_claudebox_container "$temp_container" "interactive" shell "${shell_flags[@]}"
+        run_claudebox_container "$temp_container" "interactive" shell "${shell_flags[@]+"${shell_flags[@]}"}"
         
         # Commit changes back to image
         fillbar
@@ -127,7 +127,7 @@ _cmd_shell() {
         success "Changes saved to image!"
     else
         # Regular shell mode - just run without committing
-        run_claudebox_container "" "interactive" shell "${shell_flags[@]}"
+        run_claudebox_container "" "interactive" shell "${shell_flags[@]+"${shell_flags[@]}"}"
     fi
     
     exit 0

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -296,15 +296,18 @@ run_claudebox_container() {
     # Set up cleanup trap for temporary MCP config files
     cleanup_mcp_files() {
         local file
-        for file in "${mcp_temp_files[@]}"; do
-            if [[ -f "$file" ]]; then
-                rm -f "$file"
-            fi
-        done
-        if [[ -n "$user_mcp_file" ]] && [[ -f "$user_mcp_file" ]]; then
+        # Check if array exists and has elements (set -u safe)
+        if [[ -n "${mcp_temp_files+set}" ]] && [ ${#mcp_temp_files[@]} -gt 0 ]; then
+            for file in "${mcp_temp_files[@]}"; do
+                if [[ -f "$file" ]]; then
+                    rm -f "$file"
+                fi
+            done
+        fi
+        if [[ -n "${user_mcp_file:-}" ]] && [[ -f "$user_mcp_file" ]]; then
             rm -f "$user_mcp_file"
         fi
-        if [[ -n "$project_mcp_file" ]] && [[ -f "$project_mcp_file" ]]; then
+        if [[ -n "${project_mcp_file:-}" ]] && [[ -f "$project_mcp_file" ]]; then
             rm -f "$project_mcp_file"
         fi
     }

--- a/main.sh
+++ b/main.sh
@@ -592,6 +592,10 @@ LABEL claudebox.project=\"$project_folder_name\""
     local temp_pi temp_lbs
     temp_pi=$(mktemp) || error "Failed to create temp file"
     temp_lbs=$(mktemp) || error "Failed to create temp file"
+    
+    # Trap to ensure temp files are cleaned up on any exit
+    trap 'rm -f "$temp_pi" "$temp_lbs"' EXIT INT TERM
+    
     printf '%s' "$profile_installations" > "$temp_pi"
     printf '%s' "$labels" > "$temp_lbs"
     
@@ -611,8 +615,10 @@ LABEL claudebox.project=\"$project_folder_name\""
     }
     # Otherwise, print the line unchanged
     { print }
-    ' <<<"$base_dockerfile") || { rm -f "$temp_pi" "$temp_lbs"; error "Failed to apply Dockerfile substitutions"; }
+    ' <<<"$base_dockerfile") || error "Failed to apply Dockerfile substitutions"
     
+    # Clear trap and cleanup temp files
+    trap - EXIT INT TERM
     rm -f "$temp_pi" "$temp_lbs"
 
     # Guard: ensure no unreplaced placeholders remain


### PR DESCRIPTION
## Description

Fixes "unbound variable" errors on macOS when running ClaudeBox with default Bash 3.2.

Fixes #71

## Problem

ClaudeBox fails on macOS with errors like:

```
.claudebox/source/lib/cli.sh: line 22: all_args[@]: unbound variable
.claudebox/source/lib/cli.sh: line 52: host_flags[@]: unbound variable
```

This occurs because:
1. macOS ships with Bash 3.2 (from 2006) by default
2. ClaudeBox uses `set -u` flag (treats unset variables as errors)
3. Bash 3.2 has limitations with empty array handling

Current workaround is `brew install bash`, but this shouldn't be required.

## Root Cause

When `set -u` is enabled and arrays are empty, Bash 3.2 treats `${array[@]}` as an unbound variable error. This affects:
- Command-line argument parsing (`lib/cli.sh`)
- Array iteration in multiple modules
- Array exports and expansions

## When This Broke

This issue was introduced in commit [1e621cc](https://github.com/RchGrav/claudebox/commit/1e621cc) (July 12, 2025) during the "CLI architecture overhaul" which:
1. Introduced `set -euo pipefail` flags to the main script
2. Created new CLI parsing with array-based argument buckets
3. Used array patterns incompatible with Bash 3.2 + `set -u`

Issue #71 was reported 2 months later (September 9, 2025) when macOS users started encountering the errors.

## Solution

Applied Bash 3.2 + `set -u` compatible patterns throughout the codebase:

### Safe Array Expansion
```bash
# Before (breaks in Bash 3.2 with set -u)
"${array[@]}"

# After (Bash 3.2 compatible)
"${array[@]+"${array[@]}"}"
```

### Safe Array Iteration
```bash
# Before (breaks on empty arrays)
for item in "${array[@]}"; do
    process "$item"
done

# After (guards against empty arrays)
if [ ${#array[@]} -gt 0 ]; then
    for item in "${array[@]+"${array[@]}"}"; do
        process "$item"
    done
fi
```

### Safe Parameter Expansion in Traps
```bash
# Before
if [[ -n "$var" ]] && [[ -f "$var" ]]; then

# After
if [[ -n "${var:-}" ]] && [[ -f "$var" ]]; then
```

## Files Changed

- `lib/cli.sh` - Fixed argument parsing arrays
- `lib/commands.core.sh` - Safe array expansions
- `lib/commands.profile.sh` - Guards for empty profile arrays
- `lib/config.sh` - Replaced `readarray` (Bash 4+) with `while read` loops
- `lib/docker.sh` - Safe cleanup trap array handling
- `main.sh` - Temp files for awk instead of complex string substitutions
- `build/docker-entrypoint` - Removed problematic `local` in subshells

## Testing

Tested on:
- ✅ macOS 14.6 (Bash 3.2.57) - Installation and basic usage work
- ✅ Linux (Bash 4+) - No regressions, all features work

Verified fixes:
- ✅ `./claudebox.run` installs without "unbound variable" errors
- ✅ `claudebox add python` works
- ✅ `claudebox shell` works
- ✅ Array handling safe across all modules

## Impact

- **Compatibility**: macOS (Bash 3.2) and Linux (Bash 4+)
- **Breaking changes**: None
- **Performance**: No impact
- **Users affected**: All macOS users (M1, M2, M3, M4)

## Comparison with PR #77

This PR takes a similar approach to #77 but focuses on:
- Comprehensive fixes across all modules (7 files)
- Consistent use of safe array expansion patterns
- Bash 3.2 compatible alternatives (no `readarray`)
- Clear documentation of each pattern

## Related Issues

- #71 - Multiple users reporting this on M1/M4 Macs
- #77 - Alternative fix (still open)

## Summary by Sourcery

Enable Bash 3.2 compatibility with set -u by guarding empty array expansions, replacing Bash-4+ features, and refactoring array and Dockerfile handling across all scripts

Bug Fixes:
- Prevent unbound variable errors on macOS Bash 3.2 by guarding array expansions and iterations under set -u

Enhancements:
- Adopt "${array[@]+\"${array[@]}\"}" pattern and length checks to safely iterate and export arrays
- Replace readarray usage with POSIX-compatible while-read loops for array population
- Refactor Dockerfile templating to use temporary files and safe awk loops instead of multiline -v expansions