### PR TITLE
Homebrew support

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -371,7 +371,7 @@ get_profile_ml() {
 get_profile_homebrew() {
     local packages=$(get_profile_packages "homebrew")
     if [[ -n "$packages" ]]; then
-        echo "RUN apt-get update && apt-get install --no-install-recommends -y $packages && apt-get clean"
+        echo "RUN apt-get update && apt-get install -y $packages && apt-get clean"
     fi
     cat << 'EOF'
 USER claude

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -379,6 +379,7 @@ USER claude
 # Homebrew does not publish versioned releases of its install script
 RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+RUN brew --version  # Confirm installation
 
 USER root
 EOF

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -390,3 +390,4 @@ export -f get_profile_core get_profile_build_tools get_profile_shell get_profile
 export -f get_profile_rust get_profile_python get_profile_go get_profile_flutter get_profile_javascript get_profile_java get_profile_ruby
 export -f get_profile_php get_profile_database get_profile_devops get_profile_web get_profile_embedded get_profile_datascience
 export -f get_profile_security get_profile_ml get_profile_homebrew
+

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -391,5 +391,4 @@ export -f get_profile_file_path read_config_value read_profile_section update_pr
 export -f get_profile_core get_profile_build_tools get_profile_shell get_profile_networking get_profile_c get_profile_openwrt
 export -f get_profile_rust get_profile_python get_profile_go get_profile_flutter get_profile_javascript get_profile_java get_profile_ruby
 export -f get_profile_php get_profile_database get_profile_devops get_profile_web get_profile_embedded get_profile_datascience
-export -f get_profile_security get_profile_ml 
-export -f get_profile_homebrew
+export -f get_profile_security get_profile_ml get_profile_homebrew

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -35,7 +35,7 @@ get_profile_packages() {
         datascience) echo "r-base" ;;
         security) echo "nmap tcpdump wireshark-common netcat-openbsd john hashcat hydra" ;;
         ml) echo "" ;;  # Just cmake needed, comes from build-tools now
-        homebrew) echo "build-essential curl file procps locales" ;;
+        homebrew) echo "build-essential curl file procps" ;;
         *) echo "" ;;
     esac
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -35,7 +35,7 @@ get_profile_packages() {
         datascience) echo "r-base" ;;
         security) echo "nmap tcpdump wireshark-common netcat-openbsd john hashcat hydra" ;;
         ml) echo "" ;;  # Just cmake needed, comes from build-tools now
-        homebrew) echo "build-essential curl file procps locales" ;; 
+        homebrew) echo "build-essential curl file procps locales" ;;
         *) echo "" ;;
     esac
 }
@@ -63,7 +63,7 @@ get_profile_description() {
         datascience) echo "Data Science (Python, Jupyter, R)" ;;
         security) echo "Security Tools (scanners, crackers, packet tools)" ;;
         ml) echo "Machine Learning (build layer only; Python via uv)" ;;
-        homebrew) echo "Package Manager" ;; 
+        homebrew) echo "Package Manager" ;;
         *) echo "" ;;
     esac
 }
@@ -376,15 +376,14 @@ get_profile_homebrew() {
     cat << 'EOF'
 USER claude
 
+# Homebrew does not publish versioned releases of its install script
 RUN /bin/bash -c "$(curl -fL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
-RUN brew update
 
 USER root
 
 EOF
 }
-
 
 export -f _read_ini get_profile_packages get_profile_description get_all_profile_names profile_exists expand_profile
 export -f get_profile_file_path read_config_value read_profile_section update_profile_section get_current_profiles

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -374,11 +374,23 @@ get_profile_homebrew() {
         echo "RUN apt-get update && apt-get install --no-install-recommends -y $packages && apt-get clean"
     fi
     cat << 'EOF'
-# Run the Homebrew installation script
-RUN yes | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Create a non-root user to own brew
+RUN useradd -m -s /bin/bash linuxbrew
 
-# Add Homebrew to the PATH environment variable
+# Switch to brew user
+USER linuxbrew
+
+# Install brew
+RUN /bin/bash -c "$(curl -fL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Put brew on PATH for subsequent layers and for runtime shells
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+
+# If you need to use brew in later RUN steps, do it after PATH is set:
+RUN brew --version && brew update
+
+# Final container runs as root again
+USER root
 
 EOF
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -377,7 +377,7 @@ get_profile_homebrew() {
 USER claude
 
 # Homebrew does not publish versioned releases of its install script
-RUN /bin/bash -c "$(curl -fL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 USER root

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -374,22 +374,12 @@ get_profile_homebrew() {
         echo "RUN apt-get update && apt-get install --no-install-recommends -y $packages && apt-get clean"
     fi
     cat << 'EOF'
-# Create a non-root user to own brew
-RUN useradd -m -s /bin/bash linuxbrew
+USER claude
 
-# Switch to brew user
-USER linuxbrew
-
-# Install brew
 RUN /bin/bash -c "$(curl -fL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-# Put brew on PATH for subsequent layers and for runtime shells
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+RUN brew update
 
-# If you need to use brew in later RUN steps, do it after PATH is set:
-RUN brew --version && brew update
-
-# Final container runs as root again
 USER root
 
 EOF

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -391,4 +391,5 @@ export -f get_profile_file_path read_config_value read_profile_section update_pr
 export -f get_profile_core get_profile_build_tools get_profile_shell get_profile_networking get_profile_c get_profile_openwrt
 export -f get_profile_rust get_profile_python get_profile_go get_profile_flutter get_profile_javascript get_profile_java get_profile_ruby
 export -f get_profile_php get_profile_database get_profile_devops get_profile_web get_profile_embedded get_profile_datascience
-export -f get_profile_security get_profile_ml
+export -f get_profile_security get_profile_ml 
+export -f get_profile_homebrew

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -63,7 +63,7 @@ get_profile_description() {
         datascience) echo "Data Science (Python, Jupyter, R)" ;;
         security) echo "Security Tools (scanners, crackers, packet tools)" ;;
         ml) echo "Machine Learning (build layer only; Python via uv)" ;;
-        homebrew) echo "Package Manager" ;;
+        homebrew) echo "Homebrew Package Manager" ;;
         *) echo "" ;;
     esac
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -377,7 +377,7 @@ get_profile_homebrew() {
 USER claude
 
 # Homebrew does not publish versioned releases of its install script
-RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 USER root

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -35,7 +35,7 @@ get_profile_packages() {
         datascience) echo "r-base" ;;
         security) echo "nmap tcpdump wireshark-common netcat-openbsd john hashcat hydra" ;;
         ml) echo "" ;;  # Just cmake needed, comes from build-tools now
-        homebrew) echo "build-essential curl file procps" ;;
+        homebrew) echo "build-essential curl file procps locales" ;;
         *) echo "" ;;
     esac
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -35,6 +35,7 @@ get_profile_packages() {
         datascience) echo "r-base" ;;
         security) echo "nmap tcpdump wireshark-common netcat-openbsd john hashcat hydra" ;;
         ml) echo "" ;;  # Just cmake needed, comes from build-tools now
+        homebrew) echo "build-essential curl file procps locales" ;; 
         *) echo "" ;;
     esac
 }
@@ -62,12 +63,13 @@ get_profile_description() {
         datascience) echo "Data Science (Python, Jupyter, R)" ;;
         security) echo "Security Tools (scanners, crackers, packet tools)" ;;
         ml) echo "Machine Learning (build layer only; Python via uv)" ;;
+        homebrew) echo "Package Manager" ;; 
         *) echo "" ;;
     esac
 }
 
 get_all_profile_names() {
-    echo "core build-tools shell networking c openwrt rust python go flutter javascript java ruby php database devops web embedded datascience security ml"
+    echo "core build-tools shell networking c openwrt rust python go flutter javascript java ruby php database devops web embedded datascience security ml homebrew"
 }
 
 profile_exists() {
@@ -83,6 +85,7 @@ expand_profile() {
         c) echo "core build-tools c" ;;
         openwrt) echo "core build-tools openwrt" ;;
         ml) echo "core build-tools ml" ;;
+        homebrew) echo "core homebrew" ;;
         rust|go|flutter|python|php|ruby|java|database|devops|web|embedded|datascience|security|javascript)
             echo "core $1"
             ;;
@@ -364,6 +367,22 @@ get_profile_ml() {
     # ML profile just needs build tools which are dependencies
     echo "# ML profile uses build-tools for compilation"
 }
+
+get_profile_homebrew() {
+    local packages=$(get_profile_packages "homebrew")
+    if [[ -n "$packages" ]]; then
+        echo "RUN apt-get update && apt-get install --no-install-recommends -y $packages && apt-get clean"
+    fi
+    cat << 'EOF'
+# Run the Homebrew installation script
+RUN yes | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Add Homebrew to the PATH environment variable
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+
+EOF
+}
+
 
 export -f _read_ini get_profile_packages get_profile_description get_all_profile_names profile_exists expand_profile
 export -f get_profile_file_path read_config_value read_profile_section update_profile_section get_current_profiles

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -381,7 +381,6 @@ RUN /bin/bash -c "$(curl -fL https://raw.githubusercontent.com/Homebrew/install/
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 USER root
-
 EOF
 }
 


### PR DESCRIPTION
This PR adds a profile for the [Homebrew](https://brew.sh/) package manager.

## Summary by Sourcery

Add a new Homebrew profile to the configuration system and wire it into the profile registry.

New Features:
- Introduce a Homebrew profile with its own package set and description.
- Provide a profile expansion for Homebrew that composes with the core profile.
- Add a Homebrew-specific profile generator that installs required system packages and Homebrew via its official install script.

Enhancements:
- Extend the exported profile functions list to include the new Homebrew profile handler.