### PR TITLE
fix: remove `local` used outside functions in docker-entrypoint

### DIFF
--- a/build/docker-entrypoint
+++ b/build/docker-entrypoint
@@ -83,7 +83,7 @@ if [ -n "${CLAUDEBOX_PROJECT_NAME:-}" ]; then
                     runuser -u DOCKERUSER -- touch "$VENV_FLAG"
                 else
                     # Someone else is fixing it, wait for completion
-                    local wait_count=0
+                    wait_count=0
                     while [ ! -f "$VENV_FLAG" ] && [ $wait_count -lt 60 ]; do
                         sleep 0.5
                         ((wait_count++)) || true
@@ -106,7 +106,7 @@ if [ -n "${CLAUDEBOX_PROJECT_NAME:-}" ]; then
                     runuser -u DOCKERUSER -- touch "$VENV_FLAG"
                 else
                     # Someone else is creating it, wait for completion flag
-                    local wait_count=0
+                    wait_count=0
                     while [ ! -f "$VENV_FLAG" ] && [ $wait_count -lt 60 ]; do
                         sleep 0.5
                         ((wait_count++)) || true
@@ -138,7 +138,7 @@ if [ -n "${CLAUDEBOX_PROJECT_NAME:-}" ]; then
         if [ -f "$CONFIG_FILE" ] && grep -qE 'python|ml|datascience' "$CONFIG_FILE"; then
             if [ ! -f "$PYDEV_FLAG" ] && [ -f "$VENV_FLAG" ] && [ -d "$VENV_DIR" ]; then
                 # Deploy Python dev tools based on profile
-                local python_packages=""
+                python_packages=""
                 
                 # Base Python profile packages
                 if grep -q 'python' "$CONFIG_FILE"; then


### PR DESCRIPTION
## Summary

Remove three `local` keyword usages at top-level scope in `build/docker-entrypoint` (lines 86, 109, 141) that cause the container to fail on startup.

## Problem

The entrypoint script has `set -euo pipefail` and uses `local` outside of any function. Bash rejects this:

```
/usr/local/bin/docker-entrypoint: line 141: local: can only be used in a function
```

This causes the container to exit immediately after a successful build, making ClaudeBox unusable once profiles that trigger Python venv setup are enabled.

## Fix

Replace `local` with plain variable assignments. These variables (`wait_count`, `python_packages`) are already deeply nested in conditionals and don't need function-scoped locality.

Fixes #65

## Summary by Sourcery

Bug Fixes:
- Remove invalid uses of the bash `local` keyword at top-level scope in the docker entrypoint script that caused startup failures.